### PR TITLE
Release alpha.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
-## [1.0.0-alpha.11] 2026-05-06
+## [1.0.0-alpha.12] 2026-05-06
 
 ### Fixed
 
 - Rename `hasIncome` -> `hasInput` and `hasOutcome` -> `hasOutput` in `AsPlannedTransformation`.
 - Rename `incomeOf` > `inputOf` in `AsPlannedConsumptionFlow`.
 - Rename `outcomeOf` -> `outpufOf` in `AsPlannedProductionFlow`.
+
+## [1.0.0-alpha.11] 2025-05-27
+
+NPM alignment release (same as 1.0.0-alpha.10).
 
 ## [1.0.0-alpha.10] - 2025-04-28
 
@@ -183,7 +187,8 @@ See the SUPPORTED.md file [comparison from main to next](https://github.com/data
 
 - Initial release.
 
-[unreleased]: https://github.com/datafoodconsortium/connector-typescript/compare/v1.0.0-alpha.11...HEAD
+[unreleased]: https://github.com/datafoodconsortium/connector-typescript/compare/v1.0.0-alpha.12...HEAD
+[1.0.0-alpha.12]: https://github.com/datafoodconsortium/connector-typescript/compare/v1.0.0-alpha.11...v1.0.0-alpha.12
 [1.0.0-alpha.11]: https://github.com/datafoodconsortium/connector-typescript/compare/v1.0.0-alpha.10...v1.0.0-alpha.11
 [1.0.0-alpha.10]: https://github.com/datafoodconsortium/connector-typescript/compare/v1.0.0-alpha.9...v1.0.0-alpha.10
 [1.0.0-alpha.9]: https://github.com/datafoodconsortium/connector-typescript/compare/v1.0.0-alpha.8...v1.0.0-alpha.9

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datafoodconsortium/connector",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datafoodconsortium/connector",
-      "version": "1.0.0-alpha.11",
+      "version": "1.0.0-alpha.12",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/serializer-jsonld-ext": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Maxime Lecoq",
   "license": "MIT",
   "type": "module",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/datafoodconsortium/connector-typescript.git",


### PR DESCRIPTION
### Fixed

- Rename `hasIncome` -> `hasInput` and `hasOutcome` -> `hasOutput` in `AsPlannedTransformation`.
- Rename `incomeOf` > `inputOf` in `AsPlannedConsumptionFlow`.
- Rename `outcomeOf` -> `outpufOf` in `AsPlannedProductionFlow`.

Fix alpha.11 that was an NPM alignment release (same as 1.0.0-alpha.10).

Fixes https://github.com/datafoodconsortium/data-model-uml/issues/30.